### PR TITLE
Refactor: Update permission and labels for activity listing

### DIFF
--- a/src/app/components/main/main.component.html
+++ b/src/app/components/main/main.component.html
@@ -30,7 +30,7 @@
       </a>
 
       <!--Listar atividades-->
-      <a class="sub-option" *ngIf="expandedActivity && authenticatedUser.permissions.includes('view_activity')"
+      <a class="sub-option" *ngIf="expandedActivity && authenticatedUser.permissions.includes('list_activity')"
         [routerLink]="['activity-table', 'activity']" routerLinkActive="active">
         <i class="material-icons option-icon">list</i>
         Listar atividades

--- a/src/app/components/user/user-create/user-create.component.ts
+++ b/src/app/components/user/user-create/user-create.component.ts
@@ -53,6 +53,7 @@ export class UserCreateComponent implements OnInit {
     'view_history',
     'create_checklist',
     'create_activity',
+    'list_activity',
     'reports',
   ];
 
@@ -93,6 +94,7 @@ export class UserCreateComponent implements OnInit {
       'view_history': 'Visualizar histórico de atividades',
       'create_checklist': 'Realizar checklist',
       'create_activity': 'Cadastrar atividade',
+      'list_activity': 'Listar atividades',
       'reports': 'Exportar Relatórios',
     };
 

--- a/src/app/components/user/user-list/user-list.component.ts
+++ b/src/app/components/user/user-list/user-list.component.ts
@@ -146,7 +146,7 @@ export class UserListComponent implements OnInit {
       view_history: 'Visualizar histórico de atividades',
       create_checklist: 'Realizar checklist',
       create_activity: 'Cadastrar nova atividade',
-      view_activity: 'Visualizar atividades cadastradas',
+      list_activity: 'Visualizar atividades cadastradas',
       reports: 'Exportar Relatórios',
     };
 

--- a/src/app/interfaces/user.interface.ts
+++ b/src/app/interfaces/user.interface.ts
@@ -1,4 +1,4 @@
-export type Permissions = 'create_users' | 'view_users' | 'edit_users' | 'view_history' | 'create_checklist' | 'create_activity' | 'reports';
+export type Permissions = 'create_users' | 'view_users' | 'edit_users' | 'view_history' | 'create_checklist' | 'create_activity' | 'list_activity' | 'reports';
 
 export type Context = 'create' | 'edit';
 


### PR DESCRIPTION
This pull request refactors the permission and labels for the activity listing feature. It updates the permission check in the HTML template to use the 'list_activity' permission instead of 'view_activity'. It also updates the labels in the user create and user list components to use 'list_activity' instead of 'view_activity'. This change ensures consistency and clarity in the codebase.